### PR TITLE
fix(template): use map instead of forEach to preserve sort order

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -45,17 +45,13 @@ module.exports = function(name, fields) {
 
 function transformObject(template, object, options, callback) {
   if (_.isArray(object)) {
-    // Recursively process array elements
-
-    var results = [];
-    async.forEach(object, function(object, next) {
+    async.map(object, function(object, next) {
       transformObject(template, object, options, function(err, representation) {
         if (err) return next(err);
 
-        results.push(representation);
-        return next();
+        return next(null, representation);
       });
-    }, function(err) {
+    }, function(err, results) {
       return callback(err, results);
     });
   } else if (object !== null && typeof object === 'object' && template) {

--- a/test/index.js
+++ b/test/index.js
@@ -271,7 +271,7 @@ describe('Jiggler', function() {
       });
     });
 
-    it('should represent an array', function(done) {
+    it('should represent an array and preserve order', function(done) {
       var User = function() {
         this.firstName = '';
         this.lastName = '';
@@ -279,13 +279,27 @@ describe('Jiggler', function() {
       var user = new User();
       user.firstName = 'Davos';
       user.lastName = 'Seaworth';
+      user.timeout = 200;
       var user2 = new User();
       user2.firstName = 'Sandor';
       user2.lastName = 'Clegane';
+      user2.timeout = 100;
 
       var fields = [
-        J.Field('firstName'),
-        J.Field('lastName')
+        J.Field('firstName', {
+          src: function (object, context, callback) {
+            setTimeout(function () {
+              callback(null, object.firstName);
+            }, object.timeout);
+          }
+        }),
+        J.Field('lastName', {
+          src: function (object, context, callback) {
+            setTimeout(function () {
+              callback(null, object.lastName);
+            }, object.timeout);
+          }
+        })
       ];
       J.define('user_public', fields);
 


### PR DESCRIPTION
Using `async.forEach` here didn't guarantee that the sort order of the output array matched the input array. Changed this to an `async.map` so that order would be preserved.

@bromanko @gmauricio 